### PR TITLE
Improving the ClientError message to provide a more informative error message.

### DIFF
--- a/lib/zenodo/client.rb
+++ b/lib/zenodo/client.rb
@@ -56,9 +56,9 @@ module Zenodo
         when 200..299
           return response
         when 404
-          raise ResourceNotFoundError.new(response: response)
+          raise ResourceNotFoundError.new(method: method, url:token_url, headers:headers, response: response)
         else
-          raise ClientError.new(response: response)
+          raise ClientError.new(method: method, url:token_url, headers:headers, response: response)
       end
     end
   end

--- a/lib/zenodo/errors/client_error.rb
+++ b/lib/zenodo/errors/client_error.rb
@@ -1,7 +1,13 @@
 module Zenodo
   module Errors
     class ClientError < StandardError
-      def initialize(response:)
+      def initialize(method:, url:, headers:, response:)
+        super <<-STR.gsub(/^\s*/, '')
+          HTTP #{method} #{url}
+          Request Headers: #{headers}
+          Response Headers: #{response.headers}\n
+          Response Body:\n#{response.body}
+        STR
         @response = response
       end
     end

--- a/spec/zenodo/errors_spec.rb
+++ b/spec/zenodo/errors_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+shared_examples "zenodo/errors/client_error" do
+  subject(:client_error){ described_class.new(
+    method:method,
+    url:url,
+    headers:headers,
+    response:response
+  )}
+
+  let(:method){ "POST" }
+  let(:url){ "http://www.example.com" }
+  let(:headers){ "request headers here" }
+  let(:response){ double("Response", headers: "response headers", body: "response body") }
+
+  it "prints out a helpful error message" do
+    expected_error_message = <<-ERROR.gsub(/^\s*/, '')
+       HTTP POST http://www.example.com
+       Request Headers: request headers here
+       Response Headers: response headers
+       Response Body:
+       response body
+    ERROR
+
+    expect{
+      raise client_error
+    }.to raise_error(Zenodo::Errors::ClientError, expected_error_message)
+  end
+end
+
+describe Zenodo::Errors::ClientError  do
+  include_examples "zenodo/errors/client_error"
+end
+
+describe Zenodo::Errors::ResourceNotFoundError  do
+  include_examples "zenodo/errors/client_error"
+end


### PR DESCRIPTION
Hey! I've been exploring Zenodo and came across this gem. Thank you for that! 

I ended up getting the `ClientError` a few times and found it was helpful to have more information about the error itself and the request it represented.

I thought it may be useful for others as well. Thanks!
