### PR TITLE
Fix Zenodo::Resources::Object::Attributes#method_missing

### DIFF
--- a/lib/zenodo/resources/object/attributes.rb
+++ b/lib/zenodo/resources/object/attributes.rb
@@ -47,8 +47,8 @@ module Zenodo::Resources::Object::Attributes
   end
 
   def method_missing(name, *args, &block)
-    attribute = name.to_s.upcase
-    if __getobj__.key?(attribute)
+    name = name.to_s
+    if __getobj__.key?(name)
       self.class.define_attribute_accessor(name)
       deserialize_attribute(name, self.class.attributes[name.to_sym])
     else


### PR DESCRIPTION
This is so #method_missing can successfully lookup attributes on the source object that SimpleDelegator is using. 
- name was coming thru as a symbol, but attributes are stored as string keys on the source object
- attributes aren't upper-cased, so don't uppercase name

Now it works:

```
irb> attributes =     {
?>       'metadata' => {
?>         'title' => 'My first upload',
?>         'upload_type' => 'poster',
?>         'description' => 'This is my first upload',
?>         'creators' =>[{'name' => 'Doe, Jane','affiliation' => 'ZENODO'}]
>>       }
>>     }
=> {"metadata"=>{"title"=>"My first upload", "upload_type"=>"poster", "description"=>"This is my first upload", "creators"=>[{"name"=>"Doe, Jane", "affiliation"=>"ZENODO"}]}}
irb> deposition = Zenodo.client.create_deposition(deposition:attributes)
=> #<Zenodo::Resources::Deposition:0x007fe572b80718 @files=nil @created=nil @title=nil @modified=nil @submitted=nil @state=nil @owner=nil @id=nil @metadata=nil>
irb> deposition.inspect
=> "#<Zenodo::Resources::Deposition:0x007fe572b80718 @files=nil @created=nil @title=nil @modified=nil @submitted=nil @state=nil @owner=nil @id=nil @metadata=nil>"
```
