### PR TITLE
Upgrade mime-types dependency to the latest.

### DIFF
--- a/zenodo.gemspec
+++ b/zenodo.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.9'
   spec.add_dependency 'activesupport', '~> 4.1'
-  spec.add_dependency 'mime-types', '~> 1.2'
+  spec.add_dependency 'mime-types', '~> 2.6'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Upgrade mime-types dependency to the latest. The 1.2 version is a few years old now. 

This doesn't seem to break anything. This fixes  Gemfile.lock issue where I was already using a 2.x version of mime-types, but using zenodo would have forced me to downgrade to 1.2 series.
