### PR TITLE
Make method definitions backwards compatible with Ruby 2.0.

### DIFF
--- a/lib/zenodo/dsl/deposition_actions.rb
+++ b/lib/zenodo/dsl/deposition_actions.rb
@@ -5,8 +5,9 @@ module Zenodo
     # Publish POST deposit/depositions/:id/actions/publish
     # Publishes a deposition.
     # Note publishing will fail if no files are associated with the deposition.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to publish a deposition with.
+    # @option options [String, Fixnum] :id A deposition's ID.
+    # @raise [ArgumentError] If the given :id is blank.
     # @return [Zenodo::Resources::deposition, nil].
     def publish_deposition(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")
@@ -15,8 +16,9 @@ module Zenodo
 
     # Edit POST deposit/depositions/:id/actions/edit
     # Unlock already submitted deposition for editing.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to edit a deposition with.
+    # @option options [String, Fixnum] :id A deposition's ID.
+    # @raise [ArgumentError] If the given :id is blank.
     # @return [Zenodo::Resources::deposition, nil].
     def edit_deposition(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")
@@ -25,8 +27,9 @@ module Zenodo
 
     # Discard POST deposit/depositions/:id/actions/discard
     # Discard changes in the current editing session.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to discard a deposition with.
+    # @option options [String, Fixnum] :id A deposition's ID.
+    # @raise [ArgumentError] If the given :id is blank.
     # @return [Zenodo::Resources::deposition, nil].
     def discard_deposition(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")

--- a/lib/zenodo/dsl/deposition_actions.rb
+++ b/lib/zenodo/dsl/deposition_actions.rb
@@ -8,8 +8,8 @@ module Zenodo
     # @param [String, Fixnum] id A deposition's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Zenodo::Resources::deposition, nil].
-    def publish_deposition(id:)
-      raise ArgumentError, "ID cannot be blank" if id.blank?
+    def publish_deposition(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
       Resources::Deposition.parse(request(:post, "deposit/depositions/#{id}/actions/publish", nil, nil))
     end
 
@@ -18,8 +18,8 @@ module Zenodo
     # @param [String, Fixnum] id A deposition's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Zenodo::Resources::deposition, nil].
-    def edit_deposition(id:)
-      raise ArgumentError, "ID cannot be blank" if id.blank?
+    def edit_deposition(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
       Resources::Deposition.parse(request(:post, "deposit/depositions/#{id}/actions/edit", nil, nil))
     end
 
@@ -28,8 +28,8 @@ module Zenodo
     # @param [String, Fixnum] id A deposition's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Zenodo::Resources::deposition, nil].
-    def discard_deposition(id:)
-      raise ArgumentError, "ID cannot be blank" if id.blank?
+    def discard_deposition(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
       Resources::Deposition.parse(request(:post, "deposit/depositions/#{id}/actions/discard", nil, nil))
     end
   end

--- a/lib/zenodo/dsl/deposition_files.rb
+++ b/lib/zenodo/dsl/deposition_files.rb
@@ -4,8 +4,9 @@ module Zenodo
   module DSL::DepositionFiles
     # List GET deposit/depositions/:id/files
     # List all deposition files for a given deposition.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to get a deposition with.
+    # @option options [String, Fixnum] :id A deposition's ID.
+    # @raise [ArgumentError] If the given :id is blank.
     # @return [Array, nil].
     def get_deposition_files(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")
@@ -15,11 +16,12 @@ module Zenodo
     # Create (upload) POST deposit/depositions/:id/files
     # Upload a new file.
     # Note the upload will fail if the filename already exists.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @param [String] file_or_io The file or already open IO to upload.
-    # @param [String] filename The name of the file (optional except when an IO).
-    # @param [String] content_type The content type of the file (optional except when an IO).
-    # @raise [ArgumentError] If the required method arguments are blank.
+    # @param [Hash] options The options to create a deposition file with.
+    # @option options [String, Fixnum] :id A deposition's ID.
+    # @option options [String, IO] file_or_io The file or already open IO to upload.
+    # @option options [String] filename The name of the file (optional except when an IO).
+    # @option options [String] content_type The content type of the file (optional except when an IO).
+    # @raise [ArgumentError] If the :id or :file_or_io arguments are blank.
     # @return [Zenodo::Resources::DepositionFile].
     def create_deposition_file(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")
@@ -38,24 +40,23 @@ module Zenodo
 
     # Sort PUT deposit/depositions/:id/files
     # Sort the files for a deposition. By default, the first file is shown in the file preview.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @param [Array] deposition_files The deposition files to sort.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to sort a deposition's files with.
+    # @option options [String, Fixnum] :id A deposition's ID.
+    # @option options [Array] :deposition_files The deposition files to sort.
+    # @raise [ArgumentError] If :id or :deposition_files arguments are blank.
     # @return [Array, nil].
     def sort_deposition_files(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")
       deposition_files = options[:deposition_files] || raise(ArgumentError, "Must supply :deposition_files")
-
-      raise ArgumentError, "ID cannot be blank" if id.blank?
-      raise ArgumentError, "Deposition files cannot be blank" if deposition_files.blank?
       Resources::DepositionFile.parse(request(:put, "deposit/depositions/#{id}/files", deposition_files))
     end
 
     # Retrieve GET deposit/depositions/:id/files/:file_id
     # Retrieve a single deposition file.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @param [String] file_id A deposition file ID.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to get a deposition's file with.
+    # @option options [String, Fixnum] :id A deposition's ID.
+    # @option options [String] :file_id A deposition file ID.
+    # @raise [ArgumentError] If :id or :file_id arguments are blank.
     # @return [Zenodo::Resources::DepositionFile].
     def get_deposition_file(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")
@@ -66,10 +67,11 @@ module Zenodo
     # Update PUT deposit/depositions/:id/files/:file_id
     # Update a deposition file resource. Currently the only use is renaming an already uploaded file.
     # If you one to replace the actual file, please delete the file and upload a new file.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @param [String] file_id A deposition file ID.
-    # @param [Hash] deposition_file The deposition file to update.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to update a deposition's file with.
+    # @options option [String, Fixnum] :id A deposition's ID.
+    # @options option [String] :file_id A deposition file ID.
+    # @options option [Hash] :deposition_file The deposition file to update.
+    # @raise [ArgumentError] If the :id, :file_id, or :deposition_file arguments are blank.
     # @return [Zenodo::Resources::DepositionFile].
     def update_deposition_file(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")
@@ -81,9 +83,10 @@ module Zenodo
     # Delete DELETE deposit/depositions/:id/files/:file_id
     # Delete an existing deposition file resource.
     # Note, only deposition files for unpublished depositions may be deleted.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @param [String] file_id A deposition file ID.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to delete a deposition's file with.
+    # @options option [String, Fixnum] :id A deposition's ID.
+    # @options option [String] :file_id A deposition file ID.
+    # @raise [ArgumentError] If the :id or :file_id arguments are blank.
     # @return [Faraday::Response].
     def delete_deposition_file(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")

--- a/lib/zenodo/dsl/deposition_files.rb
+++ b/lib/zenodo/dsl/deposition_files.rb
@@ -7,8 +7,8 @@ module Zenodo
     # @param [String, Fixnum] id A deposition's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_deposition_files(id:)
-      raise ArgumentError, "ID cannot be blank" if id.blank?
+    def get_deposition_files(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
       Resources::DepositionFile.parse(request(:get, "deposit/depositions/#{id}/files", nil))
     end
 
@@ -21,9 +21,11 @@ module Zenodo
     # @param [String] content_type The content type of the file (optional except when an IO).
     # @raise [ArgumentError] If the required method arguments are blank.
     # @return [Zenodo::Resources::DepositionFile].
-    def create_deposition_file(id:, file_or_io:, filename: nil, content_type: nil)
-      raise ArgumentError, "ID cannot be blank" if id.blank?
-      raise ArgumentError, "File or IO cannot be blank" if file_or_io.blank?
+    def create_deposition_file(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
+      file_or_io = options[:file_or_io] || raise(ArgumentError, "Must supply :file_or_io")
+      filename = options[:filename]
+      content_type = options[:content_type]
 
       content_type = MIME::Types.type_for(file_or_io).first.content_type if content_type.blank?
       io = Faraday::UploadIO.new(file_or_io, content_type, filename)
@@ -40,7 +42,10 @@ module Zenodo
     # @param [Array] deposition_files The deposition files to sort.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def sort_deposition_files(id:, deposition_files:)
+    def sort_deposition_files(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
+      deposition_files = options[:deposition_files] || raise(ArgumentError, "Must supply :deposition_files")
+
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Deposition files cannot be blank" if deposition_files.blank?
       Resources::DepositionFile.parse(request(:put, "deposit/depositions/#{id}/files", deposition_files))
@@ -52,9 +57,9 @@ module Zenodo
     # @param [String] file_id A deposition file ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Zenodo::Resources::DepositionFile].
-    def get_deposition_file(id:, file_id:)
-      raise ArgumentError, "ID cannot be blank" if id.blank?
-      raise ArgumentError, "File ID cannot be blank" if file_id.blank?
+    def get_deposition_file(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
+      file_id = options[:file_id] || raise(ArgumentError, "Must supply :file_id")
       Resources::DepositionFile.parse(request(:get, "deposit/depositions/#{id}/files/#{file_id}", nil))
     end
 
@@ -66,10 +71,10 @@ module Zenodo
     # @param [Hash] deposition_file The deposition file to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Zenodo::Resources::DepositionFile].
-    def update_deposition_file(id:, file_id:, deposition_file:)
-      raise ArgumentError, "ID cannot be blank" if id.blank?
-      raise ArgumentError, "File ID cannot be blank" if file_id.blank?
-      raise ArgumentError, "Deposition file cannot be blank" if deposition_file.blank?
+    def update_deposition_file(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
+      file_id = options[:file_id] || raise(ArgumentError, "Must supply :file_id")
+      deposition_file = options[:deposition_file] || raise(ArgumentError, "Must supply :deposition_file")
       Resources::DepositionFile.parse(request(:put, "deposit/depositions/#{id}/files/#{file_id}", deposition_file))
     end
 
@@ -80,9 +85,9 @@ module Zenodo
     # @param [String] file_id A deposition file ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_deposition_file(id:, file_id:)
-      raise ArgumentError, "ID cannot be blank" if id.blank?
-      raise ArgumentError, "File ID cannot be blank" if file_id.blank?
+    def delete_deposition_file(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
+      file_id = options[:file_id] || raise(ArgumentError, "Must supply :file_id")
       request(:delete, "deposit/depositions/#{id}/files/#{file_id}", nil, nil)
     end
   end

--- a/lib/zenodo/dsl/depositions.rb
+++ b/lib/zenodo/dsl/depositions.rb
@@ -14,7 +14,8 @@ module Zenodo
     # @param [String, Fixnum] id A deposition's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Zenodo::Resources::deposition, nil].
-    def get_deposition(id:)
+    def get_deposition(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Deposition.parse(request(:get, "deposit/depositions/#{id}"))
     end
@@ -24,7 +25,8 @@ module Zenodo
     # @param [Hash] deposition The deposition to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Zenodo::Resources::deposition, nil].
-    def create_deposition(deposition:)
+    def create_deposition(options={})
+      deposition = options[:deposition] || raise(ArgumentError, "Must supply :deposition")
       raise ArgumentError, "Deposition cannot be blank" if deposition.blank?
       Resources::Deposition.parse(request(:post, "deposit/depositions/", deposition))
     end
@@ -35,9 +37,9 @@ module Zenodo
     # @param [Hash] deposition The deposition to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Zenodo::Resources::deposition, nil].
-    def update_deposition(id:, deposition:)
-      raise ArgumentError, "ID cannot be blank" if id.blank?
-      raise ArgumentError, "Deposition cannot be blank" if deposition.blank?
+    def update_deposition(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
+      deposition = options[:deposition] || raise(ArgumentError, "Must supply :deposition")
       Resources::Deposition.parse(request(:put, "deposit/depositions/#{id}", deposition))
     end
 
@@ -46,8 +48,8 @@ module Zenodo
     # @param [String, Fixnum] id A deposition's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_deposition(id:)
-      raise ArgumentError, "ID cannot be blank" if id.blank?
+    def delete_deposition(options={})
+      id = options[:id] || raise(ArgumentError, "Must supply :id")
       request(:delete, "deposit/depositions/#{id}")
     end
   end

--- a/lib/zenodo/dsl/depositions.rb
+++ b/lib/zenodo/dsl/depositions.rb
@@ -11,8 +11,9 @@ module Zenodo
 
     # GET /Deposit/Deposition/{id}
     # Get a deposition.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to get a deposition with.
+    # @option options [String, Fixnum] :id A deposition's ID.
+    # @raise [ArgumentError] If the :id is blank
     # @return [Zenodo::Resources::deposition, nil].
     def get_deposition(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")
@@ -22,8 +23,9 @@ module Zenodo
 
     # POST /Deposit/Depositions
     # Creates a deposition.
-    # @param [Hash] deposition The deposition to create.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to create a deposition with.
+    # @option options [Hash] :deposition The deposition to create.
+    # @raise [ArgumentError] If the :deposition arguments are blank.
     # @return [Zenodo::Resources::deposition, nil].
     def create_deposition(options={})
       deposition = options[:deposition] || raise(ArgumentError, "Must supply :deposition")
@@ -33,9 +35,10 @@ module Zenodo
 
     # PUT /Deposit/Depositions
     # Updates a deposition.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @param [Hash] deposition The deposition to update.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to update a deposition with.
+    # @option options [String, Fixnum] :id A deposition's ID.
+    # @option options [Hash] :deposition The deposition to update.
+    # @raise [ArgumentError] If the :id or :deposition arguments are blank.
     # @return [Zenodo::Resources::deposition, nil].
     def update_deposition(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")
@@ -45,8 +48,9 @@ module Zenodo
 
     # DELETE /Deposit/Depositions/{id}
     # Deletes a deposition.
-    # @param [String, Fixnum] id A deposition's ID.
-    # @raise [ArgumentError] If the method arguments are blank.
+    # @param [Hash] options The options to delete a deposition with.
+    # @option optoins [String, Fixnum] :id A deposition's ID.
+    # @raise [ArgumentError] If the :id argument is blank.
     # @return [Faraday::Response].
     def delete_deposition(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")

--- a/lib/zenodo/dsl/depositions.rb
+++ b/lib/zenodo/dsl/depositions.rb
@@ -17,7 +17,6 @@ module Zenodo
     # @return [Zenodo::Resources::deposition, nil].
     def get_deposition(options={})
       id = options[:id] || raise(ArgumentError, "Must supply :id")
-      raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Deposition.parse(request(:get, "deposit/depositions/#{id}"))
     end
 
@@ -29,7 +28,6 @@ module Zenodo
     # @return [Zenodo::Resources::deposition, nil].
     def create_deposition(options={})
       deposition = options[:deposition] || raise(ArgumentError, "Must supply :deposition")
-      raise ArgumentError, "Deposition cannot be blank" if deposition.blank?
       Resources::Deposition.parse(request(:post, "deposit/depositions/", deposition))
     end
 

--- a/lib/zenodo/errors/client_error.rb
+++ b/lib/zenodo/errors/client_error.rb
@@ -1,7 +1,12 @@
 module Zenodo
   module Errors
     class ClientError < StandardError
-      def initialize(method:, url:, headers:, response:)
+      def initialize(options={})
+        method = options[:method] || raise(ArgumentError, "Must supply :method")
+        url = options[:url] || raise(ArgumentError, "Must supply :url")
+        response = options[:response] || raise(ArgumentError, "Must supply :response")
+        headers = options[:headers]
+
         super <<-STR.gsub(/^\s*/, '')
           HTTP #{method} #{url}
           Request Headers: #{headers}

--- a/lib/zenodo/utils/url_helper.rb
+++ b/lib/zenodo/utils/url_helper.rb
@@ -5,7 +5,9 @@ module Zenodo
       # @param [UrlHelper] path The name of the resource path as per the URL e.g. contacts.
       # @param [Hash] params A hash of params we're turning into a querystring.
       # @return [UrlHelper] The URL of the resource with required params.
-      def self.build_url(path:, params:)
+      def self.build_url(options={})
+        path = options[:path] || raise(ArgumentError, "Must supply :path")
+        params = options[:params] || raise(ArgumentError, "Must supply :params")
         params.delete_if {|k,v| v.blank?}
         params = params.to_query
         query = path

--- a/lib/zenodo/utils/url_helper.rb
+++ b/lib/zenodo/utils/url_helper.rb
@@ -2,8 +2,10 @@ module Zenodo
   module Utils
     class UrlHelper
       # Build a URL with a querystring containing optional params if supplied.
-      # @param [UrlHelper] path The name of the resource path as per the URL e.g. contacts.
-      # @param [Hash] params A hash of params we're turning into a querystring.
+      # @param [Hash] options The options to build a URL with.
+      # @options option [String] :path The name of the resource path as per the URL e.g. contacts.
+      # @options option [Hash] :params A hash of params we're turning into a querystring.
+      # @raise [ArgumentError] If the :path or :params arguments are blank.
       # @return [UrlHelper] The URL of the resource with required params.
       def self.build_url(options={})
         path = options[:path] || raise(ArgumentError, "Must supply :path")


### PR DESCRIPTION
I recently found out that the production environment we're going to be deploying is currently on Ruby 2.0. 

This pull request downgrades the method definitions to use Hashes instead of named arguments.

No functionality changes except some of the error messages will now be formatted in the following way:

> Must supply :&lt;argname&gt;

The exception to the no functionality change is that `ClientError#initialize` doesn't require `:headers` so it can be passed in as nil. 
