### PR TITLE
Allow for a different Zenodo URL to be provided

### DIFF
--- a/lib/zenodo.rb
+++ b/lib/zenodo.rb
@@ -10,13 +10,16 @@ module Zenodo
   class << self
     # @return [String]
     attr_accessor :api_key
+    attr_accessor :url
     attr_accessor :logger
   end
+
+  self.url = 'https://zenodo.org/api/'
 
   module_function
 
   # @return [Zenodo::Client]
   def client
-    @client ||= Client.new(Zenodo.api_key)
+    @client ||= Client.new(Zenodo.api_key, Zenodo.url)
   end
 end

--- a/lib/zenodo/client.rb
+++ b/lib/zenodo/client.rb
@@ -12,13 +12,13 @@ module Zenodo
     include Errors
     include Utils
 
-    URL = 'https://zenodo.org/api/'
     REQUESTS = [:get, :post, :put, :delete]
     HEADERS = {'Accept' => 'application/json', 'Content-Type' => 'application/json'}
 
     # @param [String] api_key
-    def initialize(api_key = Zenodo.api_key)
+    def initialize(api_key = Zenodo.api_key, url = Zenodo.url)
       @api_key = api_key
+      @url = url
 
       # Setup HTTP request connection to Zenodo.
       @connection ||= Faraday.new do |builder|
@@ -40,7 +40,7 @@ module Zenodo
     def request(method, path, query = {}, headers = HEADERS)
       raise ArgumentError, "Unsupported method #{method.inspect}. Only :get, :post, :put, :delete are allowed" unless REQUESTS.include?(method)
 
-      token_url = UrlHelper.build_url(path: "#{URL}#{path}", params: {access_token: @api_key})
+      token_url = UrlHelper.build_url(path: "#{@url}#{path}", params: {access_token: @api_key})
       payload = nil
       if query.present?
         accept = headers.present? ? headers['Accept'] : nil


### PR DESCRIPTION
The driving factor for this is that Zenodo provides a sandbox environment at a different URL: https://sandbox.zenodo.org

This makes it possible to change the Zenodo URL globally with Zenodo.url or at the instance level for a Client by passing it in thru the constructor. 

Doesn't break any interfaces.
